### PR TITLE
Fix missing KBD_JAPANESE condition

### DIFF
--- a/libfreerdp/core/freerdp.c
+++ b/libfreerdp/core/freerdp.c
@@ -105,7 +105,8 @@ BOOL freerdp_connect(freerdp* instance)
 	if (status)
 		status2 = freerdp_channels_pre_connect(instance->context->channels, instance);
 
-	if (settings->KeyboardLayout == KBD_JAPANESE_INPUT_SYSTEM_MS_IME2002)
+	if (settings->KeyboardLayout == KBD_JAPANESE ||
+	    settings->KeyboardLayout == KBD_JAPANESE_INPUT_SYSTEM_MS_IME2002)
 	{
 		settings->KeyboardType = 7;
 		settings->KeyboardSubType = 2;


### PR DESCRIPTION
## What I fixed
There are 2 Japanese Keyboards in `include/freerdp/locale/keyboard.h`

```C
/* Keyboard layout IDs */
//snip
#define KBD_JAPANESE 0x00000411
//snip
/* Global Input Method Editor (IME) IDs */
//snip
#define KBD_JAPANESE_INPUT_SYSTEM_MS_IME2002 0xE0010411
//snip
```

But only `KBD_JAPANESE_INPUT_SYSTEM_MS_IME2002 0xE0010411` is cared.
So I added `KBD_JAPANESE`.

## What happens

Users cannot use a Japanese keyboard correctly from Apache guacamole when RDP session does not exist.
(If there is RDP session using a Japanese keyboard, it works correctly.)

Apache guacamole-server uses `KBD_JAPANESE`.
[guacamole-server/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap#L22](https://github.com/apache/guacamole-server/blob/29535e6cb8c072efcdb61946ce5a2f1ed7d6a15b/src/protocols/rdp/keymaps/ja_jp_qwerty.keymap#L22)
```C
parent  "base"
name    "ja-jp-qwerty"
freerdp "KBD_JAPANESE"
```

So if guacamole-server uses the Japanese keymap, FreeRDP does not change `KeyboardType` , `KeyboardSubType`, ` KeyboardFunctionKey` from the default settings.
Thongh RDP session starts with default US keyboard.

[libfreerdp/core/settings.c#L350](https://github.com/FreeRDP/FreeRDP/blob/80cd8dcdc3e0e8e0f4ca6766fa42501356866914/libfreerdp/core/settings.c#L350)
```C
	    !freerdp_settings_set_uint32(settings, FreeRDP_KeyboardSubType, 0) ||
	    !freerdp_settings_set_uint32(settings, FreeRDP_KeyboardFunctionKey, 12) ||
	    !freerdp_settings_set_uint32(settings, FreeRDP_KeyboardLayout, 0) ||
```

## What I Check

I have checked this code works with my Japanese keyboards.

### Environment

- RDP Target machine
  - Windows 10 Pro with RDP enabled
- Server
  - Ubuntu 20.04 on WSL2 on Windows 10.

- Code
  - guacamole server 1.4.0
  - freerdp in this PR